### PR TITLE
Use plain ConnectionSettings in Payload

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -92,11 +92,11 @@ def create_broker(connection_settings: ConnectionSettings, mapper: CommandMapper
 def create_command_mapper() -> CommandMapper:
     return CommandMapper() \
         .register(SubproblemResultCommand)
-      
+
 
 def broadcast_result(subproblem: Subproblem, broker: Broker):
-        command = SubproblemResultCommand(subproblem.identifier, subproblem.result)
-        broker.broadcast(command)
+    command = SubproblemResultCommand(subproblem.identifier, subproblem.result)
+    broker.broadcast(command)
 
 
 if __name__ == '__main__':

--- a/app/messaging/command_handler.py
+++ b/app/messaging/command_handler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Any, Dict, Iterable, Optional
 from dataclasses import dataclass
+from app.shared.networking import ConnectionSettings
 from .commands import Command
 
 
@@ -8,7 +9,7 @@ from .commands import Command
 class Payload:
     '''Command + information where to send it.'''
     command: Command
-    address_id: Optional[int]
+    address: Optional[ConnectionSettings]
 
 
 class CommandHandler:
@@ -22,13 +23,13 @@ class CommandHandler:
         return self
 
     def handle(self, payload: Payload) -> Iterable[Payload]:
-        command, address_id = payload.command, payload.address_id
+        command, address = payload.command, payload.address
 
         receiver = self._get_receiver(command)
         responses = list(command.invoke(receiver))
         if responses:
             for response in responses:
-                yield Payload(response, address_id)
+                yield Payload(response, address)
 
     def _get_receiver(self, command: Command) -> Optional[Any]:
         for registered_type, receiver in self._registered_types.items():

--- a/app/tests/test_broker.py
+++ b/app/tests/test_broker.py
@@ -187,7 +187,7 @@ def test_send_sendSampleCommandToSingleAgent_commandSentToSingleAgent(
 
     expected_topology = (ConnectionSettings('0.1.2.3', 123),)
     given_response_command = NetTopologyCommand(expected_topology)
-    context.broker.send(Payload(given_response_command, hash(given_agents[0])))
+    context.broker.send(Payload(given_response_command, given_agents[0]))
 
     context.wait_some()
     outgoing_packets = context.dump_outgoing_packets()


### PR DESCRIPTION
From now on, outside components that use Broker have direct access to agents' addresses. Not only does it remove a not-so-useful abstraction layer (using hash of ConnectionSettings instead of an actual object), but it may also come in handy if one wants to display e.g. a list of online agents.