### PR TITLE
Pass prune command when agents are pruned

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -7,7 +7,7 @@ from .messaging.broker import Broker, BrokerSettings
 from .messaging.logging_broker import LoggingBroker
 from .computing.facade import get_computational_problem
 from .computing.base import Subproblem, SubproblemResult, SubproblemPool
-from .computing.domain_commands import DomainCommand
+from .computing.domain_commands import DomainCommand, PruneCommand
 from .app import ApplicationSettings, ComputationManager, EmptySubproblemPoolError
 from .messaging.commands import CommandMapper
 from .messaging.command_handler import CommandHandler, CommandNotRegisteredException
@@ -108,7 +108,9 @@ def requested_subproblem_drop(subproblem, computation_manager) -> bool:
 def create_broker(broker_settings: BrokerSettings, mapper: CommandMapper) -> Broker:
     logger = get_logger('broker')
     connection = NetworkConnection(broker_settings.connection)
-    return LoggingBroker(connection, logger, mapper, broker_settings)
+    broker = LoggingBroker(connection, logger, mapper, broker_settings)
+    broker.on_prune(lambda addr: PruneCommand(addr))
+    return broker
 
 
 def create_command_mapper() -> CommandMapper:

--- a/app/computing/domain_commands.py
+++ b/app/computing/domain_commands.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from dataclasses import dataclass, make_dataclass
 from typing import List, Optional
+from app.shared.networking import ConnectionSettings
 from app.messaging.commands import Command
 import app.computing.base as base
 
@@ -97,3 +98,15 @@ def create_drop_command(identifier_type: type) -> type:
         bases=(BaseDropCommand,),
         frozen=True
     )
+
+
+@dataclass(frozen=True)
+class PruneCommand(DomainCommand):
+    address: ConnectionSettings
+
+    @classmethod
+    def get_identifier(cls) -> str:
+        return 'PRUNE'
+
+    def invoke(self, receiver: base.SubproblemPool) -> List[Command]:
+        return []

--- a/app/config.json
+++ b/app/config.json
@@ -7,6 +7,7 @@
             "address": "0.0.0.0",
             "port": 40000
         },
-        "imalive_interval": 10.0
+        "imalive_interval": 10.0,
+        "agent_timeout": 30.0
     }
 }

--- a/app/messaging/broker.py
+++ b/app/messaging/broker.py
@@ -16,6 +16,7 @@ from .command_handler import CommandHandler, CommandNotRegisteredException, Payl
 class BrokerSettings:
     connection: ConnectionSettings
     imalive_interval: float
+    agent_timeout: float
 
 
 class Broker(StoppableThread):
@@ -24,7 +25,7 @@ class Broker(StoppableThread):
         self._connection = connection
         self._command_mapper = mapper
         self._settings = settings
-        self._topology = Topology(TimeoutService(30.0)) \
+        self._topology = Topology(TimeoutService(settings.agent_timeout)) \
             .forbid_local_interfaces_addresses(connection.get_address().port)
         self._send_queue = Queue()
         self._recv_queue = Queue()

--- a/app/messaging/broker.py
+++ b/app/messaging/broker.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from app.shared.multithreading import StoppableThread
 from app.shared.networking import Packet, ConnectionSettings, NetworkIO
-from app.shared.time import TimeProvider
+from app.shared.time import TimeoutService
 from .commands import CommandMapper, Command
 from .topology import Topology, NetworkCommand, ImAliveCommand, NetTopologyCommand, RecipientNotRegisteredError
 from .command_handler import CommandHandler, CommandNotRegisteredException, Payload
@@ -24,7 +24,7 @@ class Broker(StoppableThread):
         self._connection = connection
         self._command_mapper = mapper
         self._settings = settings
-        self._topology = Topology(TimeProvider()) \
+        self._topology = Topology(TimeoutService(30.0)) \
             .forbid_local_interfaces_addresses(connection.get_address().port)
         self._send_queue = Queue()
         self._recv_queue = Queue()

--- a/app/messaging/broker.py
+++ b/app/messaging/broker.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from app.shared.multithreading import StoppableThread
 from app.shared.networking import Packet, ConnectionSettings, NetworkIO
+from app.shared.time import TimeProvider
 from .commands import CommandMapper, Command
 from .topology import Topology, NetworkCommand, ImAliveCommand, NetTopologyCommand, RecipientNotRegisteredError
 from .command_handler import CommandHandler, CommandNotRegisteredException, Payload
@@ -23,7 +24,8 @@ class Broker(StoppableThread):
         self._connection = connection
         self._command_mapper = mapper
         self._settings = settings
-        self._topology = Topology().forbid_local_interfaces_addresses(connection.get_address().port)
+        self._topology = Topology(TimeProvider()) \
+            .forbid_local_interfaces_addresses(connection.get_address().port)
         self._send_queue = Queue()
         self._recv_queue = Queue()
         self._command_handler = self._create_command_handler()

--- a/app/messaging/topology.py
+++ b/app/messaging/topology.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 from dataclasses import dataclass
 from app.shared.networking import ConnectionSettings, get_local_interfaces_ip_addresses
-from app.shared.time import TimeProvider
+from app.shared.time import TimeoutService
 from .commands import Command
 
 
@@ -19,14 +19,27 @@ class AgentState:
 class Topology:
     """Stores information about registered agents present in the network."""
 
-    def __init__(self, time_provider: TimeProvider):
+    def __init__(self, timeout_service: TimeoutService):
         self._agents: Dict[ConnectionSettings, AgentState] = dict()
         self._forbidden: Set[ConnectionSettings] = set()
-        self._time_provider = time_provider
+        self._timeout_service = timeout_service
 
     def with_forbidden(self, address: ConnectionSettings) -> Topology:
         self._forbidden.add(address)
         return self
+
+    def prune(self) -> List[ConnectionSettings]:
+        '''Remove agents that haven't responded for too long. Return list
+        of those agents' addresses.'''
+
+        def should_be_pruned(agent: AgentState) -> bool:
+            return self._timeout_service.timed_out(agent.last_connection_time)
+
+        addresses = [addr for addr, agent in self._agents.items()
+                     if should_be_pruned(agent)]
+        for addr in addresses:
+            self._agents.pop(addr)
+        return addresses
 
     def forbid_local_interfaces_addresses(self, port: int):
         local_interfaces_ips = get_local_interfaces_ip_addresses()
@@ -36,7 +49,7 @@ class Topology:
 
     def add_or_update(self, address: ConnectionSettings):
         if address not in self._forbidden:
-            current_time = self._time_provider.now()
+            current_time = self._timeout_service.now()
             self._agents[address] = AgentState.create(current_time)
 
     def add_or_update_many(self, addresses: Iterable[ConnectionSettings]):

--- a/app/shared/time.py
+++ b/app/shared/time.py
@@ -1,14 +1,12 @@
 from time import time
 
 
-class TimeProvider:
-    '''To all of you wondering what's the reason behind this class:
-    using time() alone would work just fine, so why do we need an entire
-    new class?
-    It will be useful in testing units which are time-dependent.
-    If a class has to wait e.g. 10 seconds to perform an action, we can
-    just make it *think* that 10 seconds have just passed.
-    '''
+class TimeoutService:
+    def __init__(self, timeout_threshold: float):
+        self._timeout_threshold = timeout_threshold
+
+    def timed_out(self, time_value: float) -> bool:
+        return self.now() - time_value >= self._timeout_threshold
 
     def now(self) -> float:
         return time()

--- a/app/shared/time.py
+++ b/app/shared/time.py
@@ -1,0 +1,14 @@
+from time import time
+
+
+class TimeProvider:
+    '''To all of you wondering what's the reason behind this class:
+    using time() alone would work just fine, so why do we need an entire
+    new class?
+    It will be useful in testing units which are time-dependent.
+    If a class has to wait e.g. 10 seconds to perform an action, we can
+    just make it *think* that 10 seconds have just passed.
+    '''
+
+    def now(self) -> float:
+        return time()

--- a/app/tests/test_broker.py
+++ b/app/tests/test_broker.py
@@ -45,7 +45,7 @@ class BrokerContext:
     def __init__(self):
         self._mapper = CommandMapper()
         self._connection = NetworkIOMock()
-        self._settings = BrokerSettings('1.1.1.1', 999)
+        self._settings = BrokerSettings('1.1.1.1', 999, 999)
         self.broker = Broker(self._connection, self._mapper, self._settings)
         self.broker.start()
 

--- a/app/tests/test_topology.py
+++ b/app/tests/test_topology.py
@@ -1,5 +1,6 @@
 import pytest
 
+from app.shared.time import TimeProvider
 from app.messaging.topology import Topology, NetTopologyCommand, ImAliveCommand, RecipientNotRegisteredError
 from app.messaging.commands import CommandMapper
 from app.shared.networking import ConnectionSettings
@@ -62,7 +63,7 @@ def test_imaliveMapping_sampleCommand_byteCommandContainsEmptyBrackets():
 
 def test_addOrUpdate_sampleAddress_addressPresentInReturnedAddresses():
     given_address = ConnectionSettings('1.2.3.4', 1234)
-    sut = Topology()
+    sut = Topology(TimeProvider())
 
     sut.add_or_update(given_address)
     assert given_address in sut.get_all_addresses()
@@ -73,7 +74,7 @@ def test_addOrUpdateMany_sampleAddresses_initialAndReturnedAddressesAreEqual():
         ConnectionSettings('1.2.3.4', 1000),
         ConnectionSettings('1.2.3.5', 2000)
     ]
-    sut = Topology()
+    sut = Topology(TimeProvider())
 
     sut.add_or_update_many(given_addresses)
     assert set(sut.get_all_addresses()) == set(given_addresses)
@@ -81,13 +82,13 @@ def test_addOrUpdateMany_sampleAddresses_initialAndReturnedAddressesAreEqual():
 
 def test_withForbidden_addForbiddenAddress_addressNotAdded():
     given_address = ConnectionSettings('1.2.3.4', 1000)
-    sut = Topology().with_forbidden(given_address)
+    sut = Topology(TimeProvider()).with_forbidden(given_address)
     assert given_address not in sut.get_all_addresses()
 
 
 def test_getAddresses_sampleTopology_iterableWithGivenTopology():
     given_address = ConnectionSettings('1.2.3.4', 1000)
-    sut = Topology()
+    sut = Topology(TimeProvider())
 
     sut.add_or_update(given_address)
     assert given_address in sut.get_addresses(given_address)
@@ -95,7 +96,7 @@ def test_getAddresses_sampleTopology_iterableWithGivenTopology():
 
 def test_getAddresses_unexpectedTopology_raise():
     given_address = ConnectionSettings('1.2.3.4', 1000)
-    sut = Topology()
+    sut = Topology(TimeProvider())
 
     with pytest.raises(RecipientNotRegisteredError):
         sut.get_addresses(given_address)
@@ -107,7 +108,7 @@ def test_getAddresses_none_allRegisteredAddresses():
         ConnectionSettings('1.2.3.5', 2000)
     ]
 
-    sut = Topology()
+    sut = Topology(TimeProvider())
     sut.add_or_update_many(given_addresses)
 
     assert all(addr in sut.get_addresses(None) for addr in given_addresses)

--- a/app/tests/test_topology.py
+++ b/app/tests/test_topology.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.shared.time import TimeProvider
+from app.shared.time import TimeoutService
 from app.messaging.topology import Topology, NetTopologyCommand, ImAliveCommand, RecipientNotRegisteredError
 from app.messaging.commands import CommandMapper
 from app.shared.networking import ConnectionSettings
@@ -20,6 +20,18 @@ class MapperFactory:
     @staticmethod
     def create(type_to_register: type) -> CommandMapper:
         return CommandMapper().register(type_to_register)
+
+
+class TimeProviderMock(TimeoutService):
+    def __init__(self, timeout_threshold: float):
+        super().__init__(timeout_threshold)
+        self.current_time = 0.0
+
+    def set_time(self, value: float):
+        self.current_time = value
+
+    def now(self) -> float:
+        return self.current_time
 
 
 def test_nettopologyMapping_sampleCommand_commandMappedCorrectly():
@@ -63,7 +75,7 @@ def test_imaliveMapping_sampleCommand_byteCommandContainsEmptyBrackets():
 
 def test_addOrUpdate_sampleAddress_addressPresentInReturnedAddresses():
     given_address = ConnectionSettings('1.2.3.4', 1234)
-    sut = Topology(TimeProvider())
+    sut = Topology(TimeoutService(123))
 
     sut.add_or_update(given_address)
     assert given_address in sut.get_all_addresses()
@@ -74,7 +86,7 @@ def test_addOrUpdateMany_sampleAddresses_initialAndReturnedAddressesAreEqual():
         ConnectionSettings('1.2.3.4', 1000),
         ConnectionSettings('1.2.3.5', 2000)
     ]
-    sut = Topology(TimeProvider())
+    sut = Topology(TimeoutService(123))
 
     sut.add_or_update_many(given_addresses)
     assert set(sut.get_all_addresses()) == set(given_addresses)
@@ -82,13 +94,13 @@ def test_addOrUpdateMany_sampleAddresses_initialAndReturnedAddressesAreEqual():
 
 def test_withForbidden_addForbiddenAddress_addressNotAdded():
     given_address = ConnectionSettings('1.2.3.4', 1000)
-    sut = Topology(TimeProvider()).with_forbidden(given_address)
+    sut = Topology(TimeoutService(123)).with_forbidden(given_address)
     assert given_address not in sut.get_all_addresses()
 
 
 def test_getAddresses_sampleTopology_iterableWithGivenTopology():
     given_address = ConnectionSettings('1.2.3.4', 1000)
-    sut = Topology(TimeProvider())
+    sut = Topology(TimeoutService(123))
 
     sut.add_or_update(given_address)
     assert given_address in sut.get_addresses(given_address)
@@ -96,7 +108,7 @@ def test_getAddresses_sampleTopology_iterableWithGivenTopology():
 
 def test_getAddresses_unexpectedTopology_raise():
     given_address = ConnectionSettings('1.2.3.4', 1000)
-    sut = Topology(TimeProvider())
+    sut = Topology(TimeoutService(123))
 
     with pytest.raises(RecipientNotRegisteredError):
         sut.get_addresses(given_address)
@@ -108,7 +120,58 @@ def test_getAddresses_none_allRegisteredAddresses():
         ConnectionSettings('1.2.3.5', 2000)
     ]
 
-    sut = Topology(TimeProvider())
+    sut = Topology(TimeoutService(123))
     sut.add_or_update_many(given_addresses)
 
     assert all(addr in sut.get_addresses(None) for addr in given_addresses)
+
+
+def test_prune_sampleTopology_expectedAgentsAreReturnedFromPruned():
+    '''This test verifies values returned from prune().'''
+
+    given_addresses = [
+        ConnectionSettings('1.1.1.1', 1234),
+        ConnectionSettings('1.1.1.2', 1234),
+        ConnectionSettings('1.1.1.3', 1234)
+    ]
+    given_timeout = 5.0
+
+    time_provider = TimeProviderMock(given_timeout)
+    sut = Topology(time_provider)
+
+    time_provider.set_time(0.0)
+    sut.add_or_update_many(given_addresses)
+
+    time_provider.set_time(2.5)
+    sut.add_or_update(given_addresses[0])
+
+    time_provider.set_time(5.0)
+    pruned_agents = sut.prune()
+
+    assert set(pruned_agents) == {given_addresses[1], given_addresses[2]}
+
+
+def test_prune_sampleTopology_expectedAgentsAreRemovedFromTopology():
+    '''This test verifies if agents are actually removed from a topology.'''
+
+    given_addresses = [
+        ConnectionSettings('1.1.1.1', 1234),
+        ConnectionSettings('1.1.1.2', 1234),
+        ConnectionSettings('1.1.1.3', 1234)
+    ]
+    given_timeout = 5.0
+
+    time_provider = TimeProviderMock(given_timeout)
+    sut = Topology(time_provider)
+
+    time_provider.set_time(0.0)
+    sut.add_or_update_many(given_addresses)
+
+    time_provider.set_time(2.5)
+    sut.add_or_update(given_addresses[0])
+
+    time_provider.set_time(5.0)
+    _ = sut.prune()
+
+    all_addresses = set(sut.get_all_addresses())
+    assert all_addresses == {given_addresses[0]}


### PR DESCRIPTION
- Implement pruning the topology (removing agents that haven't sent anything for some time)
- Optionally, broker may pass PruneCommand to a main thread when aforementioned pruning occurs
- PruneCommand has no effect on SubproblemPool, yet.